### PR TITLE
Small changes

### DIFF
--- a/AutoCompleteTextField.podspec
+++ b/AutoCompleteTextField.podspec
@@ -33,9 +33,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes/**/*'
-  s.resource_bundles = {
-    'AutoCompleteTextField' => ['Pod/Assets/**/*.{png,jpeg,jpg}']
-  }
+  s.resources = "Pod/Assets/*.xcassets"
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'

--- a/Pod/Classes/AutoCompleteTextField.swift
+++ b/Pod/Classes/AutoCompleteTextField.swift
@@ -296,6 +296,7 @@ open class AutoCompleteTextField: UITextField {
         
         autoCompleteLbl.text = ""
         text = originalInputString + autocompleteString
+        sendActionsForControlEvents(.ValueChanged)
     }
     
     // MARK: - Internal Controls

--- a/Pod/Classes/AutoCompleteTextField.swift
+++ b/Pod/Classes/AutoCompleteTextField.swift
@@ -296,7 +296,7 @@ open class AutoCompleteTextField: UITextField {
         
         autoCompleteLbl.text = ""
         text = originalInputString + autocompleteString
-        sendActionsForControlEvents(.ValueChanged)
+        sendActions(for: .valueChanged)
     }
     
     // MARK: - Internal Controls


### PR DESCRIPTION
These are a couple small changes that I needed to use AutoCompleteTextField in my project.

1. The pod spec for including xcassets needed to be tweaked or it the checkmark images wouldn't be bundled.

2. I use RxSwift and if the user let the text field be autocomplete it wasn't registering the correct value in RxSwift.  Sending a value changed action event fixed it for me.

Thank you for the work you've put into this & sorry that the PR items aren't separated.  I did the work all on one branch and didn't think about it until it was too late.