### PR TITLE
Added manually providing autocomplete suggestion

### DIFF
--- a/Example/AutoCompleteTextField.xcodeproj/project.pbxproj
+++ b/Example/AutoCompleteTextField.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1D9CF18F1F4C7A040082D122 /* WeightedDomain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9CF18E1F4C7A040082D122 /* WeightedDomain.swift */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
@@ -29,6 +30,7 @@
 
 /* Begin PBXFileReference section */
 		17C5301B585551C53ECD4DD3 /* Pods_AutoCompleteTextField_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutoCompleteTextField_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1D9CF18E1F4C7A040082D122 /* WeightedDomain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeightedDomain.swift; sourceTree = "<group>"; };
 		5D4E64DDFCD5C145C5ED8141 /* AutoCompleteTextField.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = AutoCompleteTextField.podspec; path = ../AutoCompleteTextField.podspec; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* AutoCompleteTextField_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AutoCompleteTextField_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -93,6 +95,7 @@
 		607FACD21AFB9204008FA782 /* Example for AutoCompleteTextField */ = {
 			isa = PBXGroup;
 			children = (
+				1D9CF18E1F4C7A040082D122 /* WeightedDomain.swift */,
 				607FACD51AFB9204008FA782 /* AppDelegate.swift */,
 				C2CA15C71D41CB0800D1ADCB /* ViewController.swift */,
 				C2CA15C91D41CB1400D1ADCB /* Main.storyboard */,
@@ -361,6 +364,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1D9CF18F1F4C7A040082D122 /* WeightedDomain.swift in Sources */,
 				C2CA15C81D41CB0800D1ADCB /* ViewController.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 			);

--- a/Example/AutoCompleteTextField/ViewController.swift
+++ b/Example/AutoCompleteTextField/ViewController.swift
@@ -28,28 +28,38 @@ class ViewController: UIViewController, AutoCompleteTextFieldDataSource, AutoCom
                        "ymail.com",
                        "icloud.com"]
     
+    // add weighted domain names
+    var weightedDomains: [WeightedDomain] = []
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
         
         // Optional setting for delegate if not setted in IB
-        txtEmail.autoCompleteTextFieldDataSource = self
+        //        txtEmail.autoCompleteTextFieldDataSource = self
+        txtEmail.autoCompleteTextFieldManualDataSource = self
         txtReEmail.autoCompleteTextFieldDataSource = self
-
+        
         txtEmail.setDelimiter("@")
         txtReEmail.setDelimiter("@")
-
+        
         txtEmail.autoCompleteTextFieldDelegate = self
         txtReEmail.autoCompleteTextFieldDelegate = self
-
+        
         // Show right side complete button
         txtEmail.showAutoCompleteButtonWithImage(viewMode: .whileEditing)
         txtReEmail.showAutoCompleteButtonWithImage(viewMode: .whileEditing)
-
+        
         // Initializing with datasource and delegate
         /*let textFieldWithDelegateAndDataSource = AutoCompleteTextField(frame: CGRect(x: 20, y: 64, width: view.frame.width - 40, height: 40), autoCompleteTextFieldDataSource: self)
-        textFieldWithDelegateAndDataSource.backgroundColor = .red
-        view.addSubview(textFieldWithDelegateAndDataSource)*/
+         textFieldWithDelegateAndDataSource.backgroundColor = .red
+         view.addSubview(textFieldWithDelegateAndDataSource)*/
+        
+        let g1 = WeightedDomain(text: "gmail.com", weight: 10)
+        let g2 = WeightedDomain(text: "googlemail.com", weight: 5)
+        let g3 = WeightedDomain(text: "google.com", weight: 4)
+        let g4 = WeightedDomain(text: "georgetown.edu", weight: 1)
+        weightedDomains = [g1, g2, g3, g4]
     }
     
     override func didReceiveMemoryWarning() {
@@ -82,5 +92,20 @@ class ViewController: UIViewController, AutoCompleteTextFieldDataSource, AutoCom
         return true
     }
     
+}
+
+extension ViewController: AutoCompleteTextFieldManualDataSource {
+    
+    func autoCompleteTextField(_ autoCompleteTextField: AutoCompleteTextField, suggestionFor text: String) -> String? {
+        
+        let lowered = text.lowercased()
+        let filtered = weightedDomains.filter { (domain) -> Bool in
+            return domain.text.lowercased().contains(lowered)
+            }.sorted { (d1, d2) -> Bool in
+                return d1.weight > d2.weight && d1.text < d2.text
+        }
+        
+        return filtered.first?.text
+    }
 }
 

--- a/Example/AutoCompleteTextField/WeightedDomain.swift
+++ b/Example/AutoCompleteTextField/WeightedDomain.swift
@@ -1,0 +1,14 @@
+//
+//  WeightedDomain.swift
+//  AutoCompleteTextField
+//
+//  Created by AJ Bartocci on 8/22/17.
+//  Copyright © 2017 AJ Bartocci. All rights reserved.
+//
+
+import Foundation
+
+struct WeightedDomain {
+    var text: String 
+    var weight: Int
+}

--- a/Pod/Classes/AutoCompleteTextFieldProtocols.swift
+++ b/Pod/Classes/AutoCompleteTextFieldProtocols.swift
@@ -9,6 +9,13 @@
 import Foundation
 import UIKit
 
+// MARK: - AutoCompleteTextField Manual Protocol
+
+public protocol AutoCompleteTextFieldManualDataSource: AutoCompleteTextFieldDataSource {
+    
+    // Add ability to provide suggestion manually
+    func autoCompleteTextField(_ autoCompleteTextField: AutoCompleteTextField, suggestionFor text: String) -> String?
+}
 
 // MARK: - AutoCompleteTextField Protocol
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ let textFieldWithDelegateAndDataSource = AutoCompleteTextField(frame: CGRect(x: 
 
 AutoCompleteTextFieldManualDataSource conforms to the AutoCompleteTextFieldDataSource so all the functionality is the same with the added ability to manually provide autocomplete suggestions.
 
-Use the AutoCompleteTextFieldManualDataSource when providing a suggestion that is found through custom sorting. Going off the original example of email domain suggestions. The default suggestions are chosen in alphabetical order, but for better user experience we may want to certain email domains to show up if they are more popular. 
+Use the AutoCompleteTextFieldManualDataSource when providing a suggestion that is found through custom sorting. Going off the original example of email domain suggestions, the default suggestions are chosen in alphabetical order from the provided array. However, for better user experience we may want certain email domains to show up first if they are more popular. 
 
 One example may be 'gmail.com' and 'georgetown.edu'. Users are more likely to have a 'gmail.com' account so we would want that to show up before 'georgetown.edu', even though that is out of alphabetical order. 
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,42 @@ let textFieldWithDelegateAndDataSource = AutoCompleteTextField(frame: CGRect(x: 
 
 ```
 
+## AutoCompleteTextFieldManualDataSource
+
+AutoCompleteTextFieldManualDataSource conforms to the AutoCompleteTextFieldDataSource so all the functionality is the same with the added ability to manually provide autocomplete suggestions.
+
+Use the AutoCompleteTextFieldManualDataSource when providing a suggestion that is found through custom sorting. Going off the original example of email domain suggestions. The default suggestions are chosen in alphabetical order, but for better user experience we may want to certain email domains to show up if they are more popular. 
+
+One example may be 'gmail.com' and 'georgetown.edu'. Users are more likely to have a 'gmail.com' account so we would want that to show up before 'georgetown.edu', even though that is out of alphabetical order. 
+
+This is just one example. Manually providing a suggestion gives more flexibility and does not force the usage of an array of strings. 
+
+```Swift
+
+// Subclass a TextField with 'AutoCompleteTextField'
+let myTextField = AutoCompleteTextField(frame: CGRectMake(0, 0, 100, 30))
+
+// Set dataSource, it can be setted from the XCode IB like TextFieldDelegate
+myTextField.autoCompleteTextFieldManualDataSource = self
+
+// Manually provide a suggestion for the textfield
+func autoCompleteTextField(_ autoCompleteTextField: AutoCompleteTextField, suggestionFor text: String) -> String? {
+        
+    // weightedDomains = [WeightedDomain(text: "gmail.com", weight: 10), WeightedDomain(text: "georgetown.edu", weight: 1)]
+
+    let lowered = text.lowercased()
+    let filtered = weightedDomains.filter { (domain) -> Bool in
+        return domain.text.lowercased().contains(lowered)
+    }.sorted { (d1, d2) -> Bool in
+        return d1.weight > d2.weight && d1.text < d2.text
+    }
+
+    // when 'g' is typed 'gmail.com' will be chosen instead of 'georgetown.edu' becasue of weight
+    return filtered.first?.text
+}
+
+```
+
 ## Contribute
 We would love for you to contribute to `AutoCompleteTextField`. See the [LICENSE](https://github.com/nferocious76/AutoCompleteTextField/blob/master/LICENSE) file for more info.
 


### PR DESCRIPTION
Added a new datasource called AutoCompleteTextFieldManualDataSource that allows for manually providing autocomplete suggestions.  This allows for more advanced sorting beyond just alphabetical, but must be used carefully (prefix of suggestion must match string to be replaced). 