### PR TITLE
Allowing user to change color of suggestion text label

### DIFF
--- a/Pod/Classes/AutoCompleteTextField.swift
+++ b/Pod/Classes/AutoCompleteTextField.swift
@@ -173,9 +173,9 @@ open class AutoCompleteTextField: UITextField {
         let stringFilter = ignoreCase ? queryString.lowercased() : queryString
         let suggestedDomains = dataSource.filter { (domain) -> Bool in
             if ignoreCase {
-                return domain.text.lowercased().contains(stringFilter)
+                return domain.text.lowercased().hasPrefix(stringFilter)
             }else{
-                return domain.text.contains(stringFilter)
+                return domain.text.hasPrefix(stringFilter)
             }
         }
         

--- a/Pod/Classes/AutoCompleteTextField.swift
+++ b/Pod/Classes/AutoCompleteTextField.swift
@@ -70,12 +70,11 @@ open class AutoCompleteTextField: UITextField {
         didSet { actfLabel.font = font }
     }
     
-    override open var textColor: UIColor? {
+    open var suggestionColor: UIColor? {
         didSet {
-            actfLabel.textColor = textColor?.withAlphaComponent(0.5)
+            actfLabel.textColor = suggestionColor
         }
     }
-    
     
     // MARK: - Initialization
     


### PR DESCRIPTION
I didn't like the way of being forced to use same color for suggestion/autocomplete label, so I've removed the textColor observer and added another variable with suggestionColor that manipulates that. 